### PR TITLE
Optimizations:  Add '-Wall' flag and  remove unused variable.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ TARGETS = $(BINARIES)
 
 LINK.o = g++
 
-CFLAGS += -Werror -pedantic
+CFLAGS += -Werror -pedantic -Wall
 
 CXXFLAGS += $(CFLAGS)
 

--- a/src/jwt.cpp
+++ b/src/jwt.cpp
@@ -38,7 +38,6 @@ namespace jwtcpp {
 
     JWT* parse(const string& jwt)
     {
-        size_t pos;
 
         // extracting the algorithm, payload, signature and data
         char* tok = strtok((char*) jwt.c_str(), ".");


### PR DESCRIPTION
jwt.cpp: In function ‘jwtcpp::JWT\* jwtcpp::parse(const string&)’:
jwt.cpp:41:16: error: unused variable ‘pos’ [-Werror=unused-variable]
         size_t pos;
                ^
